### PR TITLE
node.js example is incorrect or outdated

### DIFF
--- a/doc_src/using.rst
+++ b/doc_src/using.rst
@@ -449,13 +449,13 @@ Node.js uses the `zeromq.node`_ binding:
 
     sock.on('message', function(msg){
         // Receive raw market JSON strings.
-        var market_json = zlib.inflate(msg);
+        zlib.inflate(msg, function(err, market_json) {
+            // Un-serialize the JSON data.
+            var market_data = JSON.parse(market_json);
 
-        // Un-serialize the JSON data.
-        var market_data = JSON.parse(market_json);
-
-        // Do something useful
-        console.log(market_data);
+            // Do something useful
+            console.log(market_data);
+        });
     });
 
 .. _zeromq.node: http://www.zeromq.org/bindings:node-js


### PR DESCRIPTION
Node.js version 0.8 (current) uses asyncronous api for zlib.inflate, see http://nodejs.org/api/zlib.html#zlib_zlib_inflate_buf_callback .

Current example for EMDR uses syncronous inflate call, which doesn't work, because zlib.inflate() always returns "undefined".
