### PR TITLE
Missing the word missing in the "Sites using EMDR"

### DIFF
--- a/doc_src/sites.rst
+++ b/doc_src/sites.rst
@@ -7,8 +7,8 @@ Sites using EMDR
 
 EMDR delivers nearly a million messages a day to a number of different
 projects around the world. Some of these projects are listed below. If we're
-a project, please file an issue in the `issue tracker`_ with the name and a
-URL to the project. Bonus points for describing what you're doing.
+missing a project, please file an issue in the `issue tracker`_ with the name 
+and a URL to the project. Bonus points for describing what you're doing.
 
 Market sites
 ------------


### PR DESCRIPTION
Added the missing "missing" word in the intro paragraph.
